### PR TITLE
pathUtils.go: change type of addition

### DIFF
--- a/pathUtils.go
+++ b/pathUtils.go
@@ -7,24 +7,24 @@ import (
 
 func pathJoin(args ...string) string {
 	var separate string
+	var join string
 	if runtime.GOOS == "windows" {
 		separate = "\\"
 	} else {
 		separate = "/"
 	}
 
-	join := ""
 	for _, arg := range args {
 		arg_replaced := strings.Replace(arg, "\\", separate, -1)
 		arg_replaced = strings.Replace(arg_replaced, "/", separate, -1)
 		if join == "" {
 			join = arg_replaced
 		} else if join[len(join) - 1:] == separate && arg_replaced[0:1] == separate {
-			join = join + arg_replaced[1:]
+			join += arg_replaced[1:]
 		} else if join[len(join) - 1:] == separate || arg_replaced[0:1] == separate {
-			join = join + arg_replaced
+			join += arg_replaced
 		} else {
-			join = join + separate + arg_replaced
+			join += (separate + arg_replaced)
 		}
 	}
 	return join


### PR DESCRIPTION
This PR reworks addition in pathutils
I've also removed direct string assignment, as go strings are empty by default